### PR TITLE
Replaced dead regex tester by another

### DIFF
--- a/content/mastering-regex.md
+++ b/content/mastering-regex.md
@@ -205,7 +205,7 @@ Cheers
 
 Thanks for [the upvotes](https://redd.it/5ziccw), some useful feedback:
 
-* To test your regexes you can use [regex101](https://regex101.com/#python) or [this site](http://www.myezapp.com/apps/dev/regexp/show.ws) for explaining how a pattern is being matched. See the Reddit thread for some other ones.
+* To test your regexes you can use [regex101](https://regex101.com/#python) or [this site](https://extendsclass.com/regex-tester.html#python) for explaining how a pattern is being matched. See the Reddit thread for some other ones.
 
 * Above HMTL examples are to show regex, but in real life you should use a parser (plenty of [options](https://www.google.com/search?q=html+parser+python&oq=html+parser+&aqs=chrome.0.0l2j69i57j0l3.2035j0j7&sourceid=chrome&ie=UTF-8)), see also SO ["You can't parse HTML with regex"](http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454).
 


### PR DESCRIPTION
Hello, I replaced myezapp.com (dead link) with extendsclass (I am the founder), It is another regex tester (with visual) for python.