### PR TITLE
exploring-python-cli bugfixes

### DIFF
--- a/content/guest-exploring-python-clis.md
+++ b/content/guest-exploring-python-clis.md
@@ -279,9 +279,9 @@ resulting in code that's easier to read and maintain.
 ```python
 import typer
 
-typer = typer.Typer()
+app = typer.Typer()
 
-@typer.command()
+@app.command()
 def echo(foo: str = 'foo', bar: str = 'bar'):
     """My Cool Program
     
@@ -290,7 +290,7 @@ def echo(foo: str = 'foo', bar: str = 'bar'):
     print(foo, bar)
     
 if __name__ == '__main__':
-    typer.run()
+    app()
 ```
 
 ## Time to Start Writing Some Code


### PR DESCRIPTION
Got caught posting code without running it thru Python first. Thanks
to reader Drew who pointed out the errors in my `typer` example.
Two fixes are needed: change instance variable `typer` to `app` to
avoid masking the module name `typer`, and second change the
invocation of the typer object from `app.run()` to just `app()`.
I've verified that this code now runs successfully :)